### PR TITLE
Bug 854389 - Missing header in emulator

### DIFF
--- a/emulator/opengl/host/tools/emugen/main.cpp
+++ b/emulator/opengl/host/tools/emugen/main.cpp
@@ -15,6 +15,7 @@
 */
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include "errors.h"
 #include "EntryPoint.h"
 #include "strUtils.h"


### PR DESCRIPTION
Another build fix.
