### PR TITLE
Build emulator according to the host architecture

### DIFF
--- a/emulator/opengl/host/libs/GLESv1_dec/Android.mk
+++ b/emulator/opengl/host/libs/GLESv1_dec/Android.mk
@@ -6,6 +6,7 @@ host_common_debug_CFLAGS :=
 #host_common_debug_CFLAGS += -DCHECK_GL_ERROR
 #host_common_debug_CFLAGS += -DDEBUG_PRINTOUT
 
+ifneq ($(shell uname -m), x86_64)
 
 ### host library #########################################
 $(call emugl-begin-host-static-library,libGLESv1_dec)
@@ -21,6 +22,7 @@ $(call emugl-export,CFLAGS,$(host_common_debug_CFLAGS))
 
 $(call emugl-end-module)
 
+else # x86_64
 
 ### host library, 64-bit ####################################
 $(call emugl-begin-host-static-library,lib64GLESv1_dec)
@@ -35,3 +37,5 @@ LOCAL_SRC_FILES := GLDecoder.cpp
 $(call emugl-export,CFLAGS,$(host_common_debug_CFLAGS) -m64)
 
 $(call emugl-end-module)
+
+endif

--- a/emulator/opengl/host/libs/GLESv2_dec/Android.mk
+++ b/emulator/opengl/host/libs/GLESv2_dec/Android.mk
@@ -6,6 +6,7 @@ host_common_debug_CFLAGS :=
 #host_common_debug_CFLAGS += -DCHECK_GL_ERROR
 #host_common_debug_CFLAGS += -DDEBUG_PRINTOUT
 
+ifneq ($(shell uname -m), x86_64)
 
 ### host library ##########################################
 $(call emugl-begin-host-static-library,libGLESv2_dec)
@@ -21,6 +22,8 @@ LOCAL_SRC_FILES := GL2Decoder.cpp
 
 $(call emugl-end-module)
 
+else # x86_64
+
 ### host library, 64-bit ####################################
 $(call emugl-begin-host-static-library,lib64GLESv2_dec)
 $(call emugl-import, lib64OpenglCodecCommon lib64OpenglOsUtils)
@@ -34,3 +37,5 @@ $(call emugl-export,CFLAGS,$(host_common_debug_CFLAGS) -m64)
 LOCAL_SRC_FILES := GL2Decoder.cpp
 
 $(call emugl-end-module)
+
+endif

--- a/emulator/opengl/host/libs/Translator/EGL/Android.mk
+++ b/emulator/opengl/host/libs/Translator/EGL/Android.mk
@@ -37,6 +37,8 @@ host_common_SRC_FILES :=      \
      EglDisplay.cpp           \
      ClientAPIExts.cpp
 
+ifneq ($(shell uname -m), x86_64)
+
 ### EGL host implementation ########################
 $(call emugl-begin-host-shared-library,libEGL_translator)
 $(call emugl-import,libGLcommon)
@@ -45,6 +47,8 @@ LOCAL_LDLIBS += $(host_common_LDLIBS)
 LOCAL_SRC_FILES := $(host_common_SRC_FILES)
 
 $(call emugl-end-module)
+
+else # x86_64
 
 ### EGL host implementation, 64-bit ########################
 $(call emugl-begin-host-shared-library,lib64EGL_translator)
@@ -55,3 +59,4 @@ LOCAL_SRC_FILES := $(host_common_SRC_FILES)
 
 $(call emugl-end-module)
 
+endif

--- a/emulator/opengl/host/libs/Translator/GLES_CM/Android.mk
+++ b/emulator/opengl/host/libs/Translator/GLES_CM/Android.mk
@@ -6,6 +6,7 @@ host_common_SRC_FILES := \
      GLEScmContext.cpp   \
      GLEScmValidate.cpp
 
+ifneq ($(shell uname -m), x86_64)
 
 ### GLES_CM host implementation (On top of OpenGL) ########################
 $(call emugl-begin-host-shared-library,libGLES_CM_translator)
@@ -16,6 +17,7 @@ LOCAL_SRC_FILES := $(host_common_SRC_FILES)
 
 $(call emugl-end-module)
 
+else # x86_64
 
 ### GLES_CM host implementation, 64-bit ########################
 $(call emugl-begin-host-shared-library,lib64GLES_CM_translator)
@@ -26,3 +28,5 @@ LOCAL_LDLIBS += -m64
 LOCAL_SRC_FILES := $(host_common_SRC_FILES)
 
 $(call emugl-end-module)
+
+endif

--- a/emulator/opengl/host/libs/Translator/GLES_V2/Android.mk
+++ b/emulator/opengl/host/libs/Translator/GLES_V2/Android.mk
@@ -7,6 +7,7 @@ host_common_SRC_FILES := \
      ShaderParser.cpp    \
      ProgramData.cpp
 
+ifneq ($(shell uname -m), x86_64)
 
 ### GLES_V2 host implementation (On top of OpenGL) ########################
 $(call emugl-begin-host-shared-library,libGLES_V2_translator)
@@ -16,6 +17,7 @@ LOCAL_SRC_FILES := $(host_common_SRC_FILES)
 
 $(call emugl-end-module)
 
+else # x86_64
 
 ### GLES_V2 host implementation, 64-bit ##############################
 $(call emugl-begin-host-shared-library,lib64GLES_V2_translator)
@@ -25,3 +27,5 @@ LOCAL_LDLIBS += -m64
 LOCAL_SRC_FILES := $(host_common_SRC_FILES)
 
 $(call emugl-end-module)
+
+endif

--- a/emulator/opengl/host/libs/Translator/GLcommon/Android.mk
+++ b/emulator/opengl/host/libs/Translator/GLcommon/Android.mk
@@ -30,6 +30,7 @@ ifeq ($(HOST_OS),windows)
     host_common_LDFLAGS += -Wl,--add-stdcall-alias
 endif
 
+ifneq ($(shell uname -m), x86_64)
 
 ### EGL host implementation ########################
 
@@ -45,6 +46,7 @@ $(call emugl-export,STATIC_LIBRARIES, libcutils libutils liblog)
 
 $(call emugl-end-module)
 
+else # x86_64
 
 ### EGL host implementation, 64-bit ################
 
@@ -59,3 +61,5 @@ $(call emugl-export,C_INCLUDES,$(LOCAL_PATH)/../include $(EMUGL_PATH)/shared)
 $(call emugl-export,STATIC_LIBRARIES, lib64cutils lib64utils lib64log)
 
 $(call emugl-end-module)
+
+endif

--- a/emulator/opengl/host/libs/libOpenglRender/Android.mk
+++ b/emulator/opengl/host/libs/libOpenglRender/Android.mk
@@ -40,6 +40,8 @@ host_common_CFLAGS :=
 #host_common_CFLAGS += -DCHECK_GL_ERROR
 
 
+ifneq ($(shell uname -m), x86_64)
+
 ### host libOpenglRender #################################################
 $(call emugl-begin-host-shared-library,libOpenglRender)
 
@@ -60,6 +62,7 @@ $(call emugl-export,CFLAGS,$(host_common_CFLAGS))
 
 $(call emugl-end-module)
 
+else # x86_64
 
 ### host libOpenglRender, 64-bit #########################################
 $(call emugl-begin-host-shared-library,lib64OpenglRender)
@@ -81,3 +84,5 @@ LOCAL_STATIC_LIBRARIES += lib64utils lib64log
 $(call emugl-export,CFLAGS,$(host_common_CFLAGS) -m64)
 
 $(call emugl-end-module)
+
+endif

--- a/emulator/opengl/host/libs/renderControl_dec/Android.mk
+++ b/emulator/opengl/host/libs/renderControl_dec/Android.mk
@@ -1,6 +1,8 @@
 LOCAL_PATH := $(call my-dir)
 
 
+ifneq ($(shell uname -m), x86_64)
+
 ### host library ############################################
 $(call emugl-begin-host-static-library,lib_renderControl_dec)
 $(call emugl-import,libOpenglCodecCommon)
@@ -8,6 +10,8 @@ $(call emugl-gen-decoder,$(LOCAL_PATH),renderControl)
 # For renderControl_types.h
 $(call emugl-export,C_INCLUDES,$(LOCAL_PATH))
 $(call emugl-end-module)
+
+else # x86_64
 
 ### host library, 64-bit ####################################
 $(call emugl-begin-host-static-library,lib64_renderControl_dec)
@@ -17,3 +21,5 @@ $(call emugl-gen-decoder,$(LOCAL_PATH),renderControl)
 $(call emugl-export,C_INCLUDES,$(LOCAL_PATH))
 $(call emugl-export,CFLAGS,-m64)
 $(call emugl-end-module)
+
+endif

--- a/emulator/opengl/host/renderer/Android.mk
+++ b/emulator/opengl/host/renderer/Android.mk
@@ -1,5 +1,7 @@
 LOCAL_PATH:=$(call my-dir)
 
+ifneq ($(shell uname -m), x86_64)
+
 # host renderer process ###########################
 $(call emugl-begin-host-executable,emulator_renderer)
 $(call emugl-import,libOpenglRender)
@@ -12,3 +14,4 @@ LOCAL_CFLAGS    += -O0 -g
 
 $(call emugl-end-module)
 
+endif

--- a/emulator/opengl/shared/OpenglCodecCommon/Android.mk
+++ b/emulator/opengl/shared/OpenglCodecCommon/Android.mk
@@ -19,6 +19,7 @@ else
     host_commonSources += UnixStream.cpp
 endif
 
+ifneq ($(shell uname -m), x86_64)
 
 ### OpenglCodecCommon  host ##############################################
 $(call emugl-begin-host-static-library,libOpenglCodecCommon)
@@ -29,6 +30,7 @@ $(call emugl-export,STATIC_LIBRARIES,libcutils)
 $(call emugl-export,C_INCLUDES,$(LOCAL_PATH))
 $(call emugl-end-module)
 
+else # x86_64
 
 ### OpenglCodecCommon  host, 64-bit #########################################
 $(call emugl-begin-host-static-library,lib64OpenglCodecCommon)
@@ -40,3 +42,4 @@ $(call emugl-export,C_INCLUDES,$(LOCAL_PATH))
 $(call emugl-export,CFLAGS,-m64)
 $(call emugl-end-module)
 
+endif

--- a/emulator/opengl/shared/OpenglOsUtils/Android.mk
+++ b/emulator/opengl/shared/OpenglOsUtils/Android.mk
@@ -27,12 +27,16 @@ ifeq ($(HOST_OS),linux)
     host_common_LDLIBS += -lpthread -lrt -lX11
 endif
 
+ifneq ($(shell uname -m), x86_64)
+
 ### 32-bit host library ####
 $(call emugl-begin-host-static-library,libOpenglOsUtils)
     $(call emugl-export,C_INCLUDES,$(LOCAL_PATH))
     LOCAL_SRC_FILES = $(host_common_SRC_FILES)
     $(call emugl-export,LDLIBS,$(host_common_LDLIBS))
 $(call emugl-end-module)
+
+else # x86_64
 
 ### 64-bit host library ####
 $(call emugl-begin-host-static-library,lib64OpenglOsUtils)
@@ -41,3 +45,5 @@ $(call emugl-begin-host-static-library,lib64OpenglOsUtils)
     $(call emugl-export,LDLIBS,$(host_common_LDLIBS))
     $(call emugl-export,CFLAGS,-m64)
 $(call emugl-end-module)
+
+endif

--- a/emulator/opengl/tests/translator_tests/GLES_CM/Android.mk
+++ b/emulator/opengl/tests/translator_tests/GLES_CM/Android.mk
@@ -1,5 +1,7 @@
 LOCAL_PATH:= $(call my-dir)
 
+ifneq ($(shell uname -m), x86_64)
+
 $(call emugl-begin-host-executable,triangleCM)
 $(call emugl-import,libEGL_translator libGLES_CM_translator)
 
@@ -27,3 +29,5 @@ $(call emugl-import,libMac_view)
 endif
 
 $(call emugl-end-module)
+
+endif

--- a/emulator/opengl/tests/translator_tests/GLES_V2/Android.mk
+++ b/emulator/opengl/tests/translator_tests/GLES_V2/Android.mk
@@ -1,5 +1,7 @@
 LOCAL_PATH:= $(call my-dir)
 
+ifneq ($(shell uname -m), x86_64)
+
 $(call emugl-begin-host-executable,triangleV2)
 $(call emugl-import,libEGL_translator libGLES_V2_translator)
 
@@ -25,3 +27,4 @@ endif
 
 $(call emugl-end-module)
 
+endif

--- a/emulator/opengl/tests/ut_rendercontrol_dec/Android.mk
+++ b/emulator/opengl/tests/ut_rendercontrol_dec/Android.mk
@@ -1,6 +1,10 @@
 LOCAL_PATH := $(call my-dir)
 
+ifneq ($(shell uname -m), x86_64)
+
 $(call emugl-begin-host-shared-library,libut_rendercontrol_dec)
 $(call emugl-import, libOpenglCodecCommon)
 $(call emugl-gen-decoder,$(LOCAL_PATH),ut_rendercontrol)
 $(call emugl-end-module)
+
+endif


### PR DESCRIPTION
Quoted from [bug 897727](https://bugzilla.mozilla.org/show_bug.cgi?id=897727) [comment 6](https://bugzilla.mozilla.org/show_bug.cgi?id=897727#c6)

> Change the emulator's build system to build only 32bit or only 64bit according to the host architecture.
> This works here (ubuntu 12.04 64bit) and ./run-emulator.sh just works. (Thanks to Gabriele Svelto for help)
