### PR TITLE
Bug 949091: When building against older OS X SDKs, don't forcefully link dylib1.o

### DIFF
--- a/emulator/opengl/common.mk
+++ b/emulator/opengl/common.mk
@@ -238,3 +238,13 @@ emugl-set-shared-library-subpath = \
     $(eval _emugl.$(LOCAL_MODULE).moved := true)\
     $(call emugl-export-outer,ADDITIONAL_DEPENDENCIES,$(LOCAL_MODULE_PATH)/$(LOCAL_MODULE)$(TARGET_SHLIB_SUFFIX))
 
+# OS X 10.6+ needs to be forced to link dylib to avoid problems
+# with the dynamic function lookups in SDL 1.2
+# NOTE: This only adds /usr/lib/dylib1.o to LDLIBS in Darwin if the 10.5/10.6 SDK
+# aren't already installed
+emugl-add-darwin-libs = \
+    $(if $(and $(wildcard /usr/lib/crt1.10.5.o),\
+               $(shell nm -a -j /usr/lib/crt1.10.5.o | grep __dyld_func_lookup)),\
+        ,\
+        $(eval LOCAL_SDL_LDLIBS += /usr/lib/dylib1.o)\
+    )

--- a/emulator/opengl/tests/translator_tests/GLES_CM/Android.mk
+++ b/emulator/opengl/tests/translator_tests/GLES_CM/Android.mk
@@ -9,9 +9,7 @@ LOCAL_SDL_CFLAGS := $(shell $(LOCAL_SDL_CONFIG) --cflags)
 LOCAL_SDL_LDLIBS := $(filter-out %.a %.lib,$(shell $(LOCAL_SDL_CONFIG) --static-libs))
 
 ifeq ($(HOST_OS),darwin)
-  # OS X 10.6+ needs to be forced to link dylib to avoid problems
-  # with the dynamic function lookups in SDL 1.2
-  LOCAL_SDL_LDLIBS += /usr/lib/dylib1.o
+  $(call emugl-add-darwin-libs)
 endif
 
 LOCAL_SRC_FILES:= \

--- a/emulator/opengl/tests/translator_tests/GLES_V2/Android.mk
+++ b/emulator/opengl/tests/translator_tests/GLES_V2/Android.mk
@@ -17,9 +17,7 @@ LOCAL_LDLIBS += $(LOCAL_SDL_LDLIBS)
 LOCAL_STATIC_LIBRARIES += libSDL libSDLmain
 
 ifeq ($(HOST_OS),darwin)
-  # OS X 10.6+ needs to be forced to link dylib to avoid problems
-  # with the dynamic function lookups in SDL 1.2
-  LOCAL_LDLIBS += /usr/lib/dylib1.o
+  $(call emugl-add-darwin-libs)
   $(call emugl-import,libMac_view)
 endif
 


### PR DESCRIPTION
This fixes a linking error in 10.8.x with more recent versions of Xcode (I tested with 5.0.1)

r? @michaelwu
